### PR TITLE
feat: distributed pagination

### DIFF
--- a/.changeset/six-cars-grin.md
+++ b/.changeset/six-cars-grin.md
@@ -1,0 +1,5 @@
+---
+"@pathery/cdk": patch
+---
+
+feat: add pagination via pagination token

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1487,7 +1487,6 @@ dependencies = [
  "tantivy-common",
  "thiserror",
  "tokio",
- "tokio-stream",
  "tracing",
  "tracing-subscriber",
  "uuid",

--- a/packages/pathery/Cargo.toml
+++ b/packages/pathery/Cargo.toml
@@ -24,7 +24,6 @@ tantivy = {version = "0.18.1"}
 tantivy-common = "0.3.0"
 thiserror = "1.0.37"
 tokio = {version = "1", features = ["full"]}
-tokio-stream = "0.1.11"
 tracing = {version = "0.1", features = ["log"]}
 tracing-subscriber = {version = "0.3", default-features = false, features = ["fmt", "json", "std"]}
 uuid = "1.2.1"

--- a/packages/pathery/src/function/query_index_partition/client.rs
+++ b/packages/pathery/src/function/query_index_partition/client.rs
@@ -1,6 +1,7 @@
 use aws_smithy_types::Blob;
 
 use super::{PartitionQueryResponse, QueryRequest};
+use crate::pagination::SegmentMeta;
 use crate::util;
 
 pub struct LambdaQueryIndexPartitionClient {
@@ -24,8 +25,9 @@ impl LambdaQueryIndexPartitionClient {
         &self,
         index_id: String,
         query: String,
-        total_partitions: usize,
+        offset: usize,
         partition_n: usize,
+        segments: Vec<SegmentMeta>,
     ) -> PartitionQueryResponse {
         // TODO: Error handling and retries
         let request = self.client.invoke();
@@ -33,8 +35,9 @@ impl LambdaQueryIndexPartitionClient {
         let input = QueryRequest {
             index_id,
             query,
+            offset,
             partition_n,
-            total_partitions,
+            segments,
         };
         let input = serde_json::to_vec(&input).expect("should serialize");
         let input = Blob::new(input);


### PR DESCRIPTION
Implements distributed pagination by encoding the offset of each partition in an opaque pagination token. The pagination token also encodes the state of the index segments at the initial query time. This ensures that results are consistent.